### PR TITLE
Fix bug of module uaclient not found.

### DIFF
--- a/uaclient/connection_dialog.py
+++ b/uaclient/connection_dialog.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QDialog, QFileDialog
 
-from uaclient.connection_ui import Ui_ConnectionDialog
+from connection_ui import Ui_ConnectionDialog
 from uawidgets.utils import trycatchslot
 
 

--- a/uaclient/mainwindow.py
+++ b/uaclient/mainwindow.py
@@ -13,9 +13,9 @@ from PyQt5.QtWidgets import QMainWindow, QWidget, QApplication, QAbstractItemVie
 from opcua import ua
 from opcua import Node
 
-from uaclient.uaclient import UaClient
-from uaclient.mainwindow_ui import Ui_MainWindow
-from uaclient.connection_dialog import ConnectionDialog
+from uaclient import UaClient
+from mainwindow_ui import Ui_MainWindow
+from connection_dialog import ConnectionDialog
 from uawidgets import resources
 from uawidgets.attrs_widget import AttrsWidget
 from uawidgets.tree_widget import TreeWidget


### PR DESCRIPTION
I got errors on your code like:
Traceback (most recent call last):
  File "app.py", line 1, in <module>
    from uaclient.mainwindow import main
  File "/home/luis/git/opcua-client-gui/uaclient/mainwindow.py", line 16, in <module>
    from uaclient.uaclient import UaClient
ImportError: No module named uaclient

I fixed it by removing the first "uaclient" on the imports, because the import come from the same package.