### PR TITLE
Fix crash when closing application certificate dialog

### DIFF
--- a/uaclient/mainwindow.py
+++ b/uaclient/mainwindow.py
@@ -8,7 +8,7 @@ import logging
 from PyQt5.QtCore import pyqtSignal, QFile, QTimer, Qt, QObject, QSettings, QTextStream, QItemSelection, \
     QCoreApplication
 from PyQt5.QtGui import QStandardItemModel, QStandardItem, QIcon
-from PyQt5.QtWidgets import QMainWindow, QMessageBox, QWidget, QApplication, QMenu
+from PyQt5.QtWidgets import QMainWindow, QMessageBox, QWidget, QApplication, QMenu, QDialog
 
 from uaclient.theme import breeze_resources
 


### PR DESCRIPTION
PR #71 added a dialog to select an application certificate.
Closing this dialog resulted in a crash of the software because of a missing import statement.
This PR adds the import of QDialog from PyQt5 to the respective file and thus fixes this error.