### PR TITLE
Modify the selection method of the parent node when calling server methods

### DIFF
--- a/uaclient/mainwindow.py
+++ b/uaclient/mainwindow.py
@@ -464,6 +464,9 @@ class Window(QMainWindow):
     def get_current_node(self, idx: QModelIndex | None = None) -> SyncNode | None:
         return self.tree_ui.get_current_node(idx)
 
+    def get_parent_node(self, idx: QModelIndex | None = None) -> SyncNode | None:
+        return self.tree_ui.get_parent_node(idx)
+
     def get_uaclient(self) -> UaClient:
         return self.uaclient
 
@@ -573,8 +576,9 @@ class Window(QMainWindow):
         node = self.get_current_node()
         if node is None:
             return
+        parent = self.get_parent_node()
         assert self.uaclient.client is not None
-        dia = CallMethodDialog(self, self.uaclient.client, node)
+        dia = CallMethodDialog(self, self.uaclient.client, parent, node)
         dia.show()
 
     def dark_mode(self) -> None:

--- a/uawidgets/call_method_dialog.py
+++ b/uawidgets/call_method_dialog.py
@@ -20,11 +20,12 @@ logger = logging.getLogger(__name__)
 
 
 class CallMethodDialog(QDialog):
-    def __init__(self, parent: QWidget | None, server: Any, node: SyncNode) -> None:
+    def __init__(self, parent: QWidget | None, server: Any, parent_node, method_node: SyncNode) -> None:
         QDialog.__init__(self, parent)
         self.setWindowTitle("UA Method Call")
         self.server = server
-        self.node = node
+        self.parent_node = parent_node
+        self.method_node = method_node
 
         self.vlayout = QVBoxLayout(self)
         self._top_layout = QHBoxLayout()
@@ -34,7 +35,7 @@ class CallMethodDialog(QDialog):
 
         self.vlayout.addWidget(QLabel("Input Arguments:", self))
         try:
-            inputs = node.get_child("0:InputArguments")
+            inputs = method_node.get_child("0:InputArguments")
             for arg in inputs.read_value():
                 self._add_input(arg)
         except ua.UaError:
@@ -48,7 +49,7 @@ class CallMethodDialog(QDialog):
 
         self.vlayout.addWidget(QLabel("Output Arguments:", self))
         try:
-            outputs = node.get_child("0:OutputArguments")
+            outputs = method_node.get_child("0:OutputArguments")
             for arg in outputs.read_value():
                 self._add_output(arg)
         except ua.UaError:
@@ -72,14 +73,13 @@ class CallMethodDialog(QDialog):
             self.result_label.setText(str(ex))
 
     def _call(self) -> None:
-        parent = self.node.get_parent()
         args = []
         for inp in self.inputs:
             data_type: SyncNode = inp.data_type  # type: ignore[attr-defined]
             val = string_to_variant(inp.text(), data_type_to_variant_type(data_type))
             args.append(val)
 
-        result = call_method_full(parent, self.node, *args)
+        result = call_method_full(self.parent_node, self.method_node, *args)
         self.result_label.setText(str(result.StatusCode))
 
         for idx, res in enumerate(result.OutputArguments):


### PR DESCRIPTION
Resolve the issue of inconsistency between the parent node obtained when calling a method when it exists on different nodes simultaneously. Change the method of obtaining the parent node to treeView.
<img width="277" height="309" alt="Snipaste_2026-06-25_09-34-12" src="https://github.com/user-attachments/assets/a83a9da6-85f5-4aa1-8ab0-fabbe83dee3c" />
